### PR TITLE
Use stricter rules in ESLint config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,5 @@
 	"useTabs": true,
 	"semi": true,
 	"singleQuote": false,
-	"printWidth": 88
+	"printWidth": 100
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,11 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
 	{ ignores: ["dist"] },
 	{
-		extends: [js.configs.recommended, ...tseslint.configs.strictTypeChecked],
+		extends: [
+			js.configs.recommended,
+			...tseslint.configs.strictTypeChecked,
+			...tseslint.configs.stylisticTypeChecked,
+		],
 		files: ["**/*.{ts,tsx}"],
 		languageOptions: {
 			ecmaVersion: 2020,
@@ -23,6 +27,7 @@ export default tseslint.config(
 		},
 		rules: {
 			...reactHooks.configs.recommended.rules,
+			"@typescript-eslint/dot-notation": ["error", { allowIndexSignaturePropertyAccess: true }],
 			"@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
 			"@typescript-eslint/restrict-template-expressions": [
 				"error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
 	{ ignores: ["dist"] },
 	{
-		extends: [js.configs.recommended, ...tseslint.configs.recommendedTypeChecked],
+		extends: [js.configs.recommended, ...tseslint.configs.strictTypeChecked],
 		files: ["**/*.{ts,tsx}"],
 		languageOptions: {
 			ecmaVersion: 2020,
@@ -23,6 +23,7 @@ export default tseslint.config(
 		},
 		rules: {
 			...reactHooks.configs.recommended.rules,
+			"@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
 			"@typescript-eslint/restrict-template-expressions": [
 				"error",
 				{

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import js from "@eslint/js";
 import globals from "globals";
+import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
@@ -17,15 +18,20 @@ export default tseslint.config(
 			ecmaVersion: 2020,
 			globals: globals.browser,
 			parserOptions: {
+				...react.configs.flat.recommended.languageOptions,
 				project: ["./tsconfig.node.json", "./tsconfig.app.json"],
 				tsconfigRootDir: import.meta.dirname,
 			},
 		},
+		settings: { react: { version: "detect" } },
 		plugins: {
+			react,
 			"react-hooks": reactHooks,
 			"react-refresh": reactRefresh,
 		},
 		rules: {
+			...react.configs.recommended.rules,
+			...react.configs["jsx-runtime"].rules,
 			...reactHooks.configs.recommended.rules,
 			"@typescript-eslint/dot-notation": ["error", { allowIndexSignaturePropertyAccess: true }],
 			"@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,11 +7,15 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
 	{ ignores: ["dist"] },
 	{
-		extends: [js.configs.recommended, ...tseslint.configs.recommended],
+		extends: [js.configs.recommended, ...tseslint.configs.recommendedTypeChecked],
 		files: ["**/*.{ts,tsx}"],
 		languageOptions: {
 			ecmaVersion: 2020,
 			globals: globals.browser,
+			parserOptions: {
+				project: ["./tsconfig.node.json", "./tsconfig.app.json"],
+				tsconfigRootDir: import.meta.dirname,
+			},
 		},
 		plugins: {
 			"react-hooks": reactHooks,
@@ -19,6 +23,19 @@ export default tseslint.config(
 		},
 		rules: {
 			...reactHooks.configs.recommended.rules,
+			"@typescript-eslint/restrict-template-expressions": [
+				"error",
+				{
+					allow: [
+						{
+							name: ["FeatureChange"],
+							from: "file",
+							path: "src/pheatures/FeatureChange.ts",
+						},
+					],
+				},
+			],
+			"@typescript-eslint/unbound-method": ["error", { ignoreStatic: true }],
 			"react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
 		},
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"@vitejs/plugin-react-swc": "^3.5.0",
 				"@vitest/coverage-v8": "^2.1.5",
 				"eslint": "^9.13.0",
+				"eslint-plugin-react": "^7.37.2",
 				"eslint-plugin-react-hooks": "^5.0.0",
 				"eslint-plugin-react-refresh": "^0.4.13",
 				"globals": "^15.11.0",
@@ -1234,9 +1235,9 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.1.tgz",
-			"integrity": "sha512-HFZ4Mp26nbWk9d/BpvP0YNL6W4UoZF0VFcTw/aPPA8RpOxeFQgK+ClABGgAUXs9Y/RGX/l1vOmrqz1MQt9MNuw==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+			"integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
 			"dev": true,
 			"dependencies": {
 				"levn": "^0.4.1"
@@ -4649,6 +4650,136 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/array-buffer-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"is-array-buffer": "^3.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array-includes": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+			"integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"is-string": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.findlast": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+			"integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.flat": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.flatmap": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+			"integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.tosorted": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+			"integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/arraybuffer.prototype.slice": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.1",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.3",
+				"es-errors": "^1.2.1",
+				"get-intrinsic": "^1.2.3",
+				"is-array-buffer": "^3.0.4",
+				"is-shared-array-buffer": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4667,6 +4798,21 @@
 			},
 			"engines": {
 				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -5057,6 +5203,25 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/call-bind": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"dev": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5223,9 +5388,9 @@
 			}
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -5263,6 +5428,57 @@
 			"version": "3.0.11",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
 			"integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+		},
+		"node_modules/data-view-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+			"integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/data-view-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+			"integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/data-view-byte-offset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+			"integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/debug": {
 			"version": "4.3.7",
@@ -5320,6 +5536,40 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -5336,6 +5586,18 @@
 			"integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/dom-accessibility-api": {
@@ -5391,11 +5653,170 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"node_modules/es-abstract": {
+			"version": "1.23.5",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
+			"integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.3",
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"data-view-buffer": "^1.0.1",
+				"data-view-byte-length": "^1.0.1",
+				"data-view-byte-offset": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-set-tostringtag": "^2.0.3",
+				"es-to-primitive": "^1.2.1",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.4",
+				"get-symbol-description": "^1.0.2",
+				"globalthis": "^1.0.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.2",
+				"internal-slot": "^1.0.7",
+				"is-array-buffer": "^3.0.4",
+				"is-callable": "^1.2.7",
+				"is-data-view": "^1.0.1",
+				"is-negative-zero": "^2.0.3",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.3",
+				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.13",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.13.3",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.5",
+				"regexp.prototype.flags": "^1.5.3",
+				"safe-array-concat": "^1.1.2",
+				"safe-regex-test": "^1.0.3",
+				"string.prototype.trim": "^1.2.9",
+				"string.prototype.trimend": "^1.0.8",
+				"string.prototype.trimstart": "^1.0.8",
+				"typed-array-buffer": "^1.0.2",
+				"typed-array-byte-length": "^1.0.1",
+				"typed-array-byte-offset": "^1.0.2",
+				"typed-array-length": "^1.0.6",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.15"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-iterator-helpers": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.0.tgz",
+			"integrity": "sha512-tpxqxncxnpw3c93u8n3VOzACmRFoVmWJqbWXvX/JfKbkhBw1oslgPrUfeSt2psuqyEJFD6N/9lg5i7bsKpoq+Q==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-set-tostringtag": "^2.0.3",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"globalthis": "^1.0.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.7",
+				"iterator.prototype": "^1.1.3",
+				"safe-array-concat": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-module-lexer": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
 			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
 			"dev": true
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.4",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-shim-unscopables": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+			"dev": true,
+			"dependencies": {
+				"hasown": "^2.0.0"
+			}
+		},
+		"node_modules/es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.21.5",
@@ -5504,6 +5925,38 @@
 				}
 			}
 		},
+		"node_modules/eslint-plugin-react": {
+			"version": "7.37.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.2.tgz",
+			"integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
+			"dev": true,
+			"dependencies": {
+				"array-includes": "^3.1.8",
+				"array.prototype.findlast": "^1.2.5",
+				"array.prototype.flatmap": "^1.3.2",
+				"array.prototype.tosorted": "^1.1.4",
+				"doctrine": "^2.1.0",
+				"es-iterator-helpers": "^1.1.0",
+				"estraverse": "^5.3.0",
+				"hasown": "^2.0.2",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
+				"minimatch": "^3.1.2",
+				"object.entries": "^1.1.8",
+				"object.fromentries": "^2.0.8",
+				"object.values": "^1.2.0",
+				"prop-types": "^15.8.1",
+				"resolve": "^2.0.0-next.5",
+				"semver": "^6.3.1",
+				"string.prototype.matchall": "^4.0.11",
+				"string.prototype.repeat": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+			}
+		},
 		"node_modules/eslint-plugin-react-hooks": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
@@ -5523,6 +5976,32 @@
 			"dev": true,
 			"peerDependencies": {
 				"eslint": ">=7"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/resolve": {
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -6090,6 +6569,15 @@
 			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
 			"dev": true
 		},
+		"node_modules/for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.1.3"
+			}
+		},
 		"node_modules/foreground-child": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -6147,6 +6635,33 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/function.prototype.name": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6164,6 +6679,25 @@
 			"peer": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/get-package-type": {
@@ -6187,6 +6721,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-symbol-description": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/glob": {
@@ -6235,6 +6786,34 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6246,6 +6825,66 @@
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
+		},
+		"node_modules/has-bigints": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
@@ -6360,10 +6999,95 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"node_modules/internal-slot": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.0",
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/is-array-buffer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"node_modules/is-async-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+			"integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dev": true,
+			"dependencies": {
+				"has-bigints": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-core-module": {
 			"version": "2.15.1",
@@ -6379,6 +7103,36 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-data-view": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+			"integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+			"dev": true,
+			"dependencies": {
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6386,6 +7140,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-finalizationregistry": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+			"integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-fullwidth-code-point": {
@@ -6407,6 +7173,21 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/is-generator-function": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -6419,6 +7200,30 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+			"integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-negative-zero": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6426,6 +7231,64 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-number-object": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-set": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+			"integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-shared-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-stream": {
@@ -6440,6 +7303,97 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+			"dev": true,
+			"dependencies": {
+				"which-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakmap": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+			"integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakref": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+			"integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -6554,6 +7508,22 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/iterator.prototype": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.3.tgz",
+			"integrity": "sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"get-intrinsic": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"reflect.getprototypeof": "^1.0.4",
+				"set-function-name": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/jackspeak": {
@@ -9410,6 +10380,21 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsx-ast-utils": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+			"integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+			"dev": true,
+			"dependencies": {
+				"array-includes": "^3.1.6",
+				"array.prototype.flat": "^1.3.1",
+				"object.assign": "^4.1.4",
+				"object.values": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -9712,6 +10697,94 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/object-inspect": {
+			"version": "1.13.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+			"integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.entries": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
+			"integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.fromentries": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+			"integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.values": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
+			"integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10002,6 +11075,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/postcss": {
 			"version": "8.4.47",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
@@ -10176,10 +11258,49 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/reflect.getprototypeof": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
+			"integrity": "sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.1",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"globalthis": "^1.0.3",
+				"which-builtin-type": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/regenerator-runtime": {
 			"version": "0.13.9",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
 			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
+			"integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"set-function-name": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -10298,10 +11419,45 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/safe-array-concat": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+			"integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">=0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"node_modules/safe-regex-test": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.1.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/scheduler": {
 			"version": "0.23.2",
@@ -10323,6 +11479,38 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -10342,6 +11530,24 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/siginfo": {
@@ -10507,6 +11713,91 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/string.prototype.matchall": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
+			"integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.7",
+				"regexp.prototype.flags": "^1.5.2",
+				"set-function-name": "^2.0.2",
+				"side-channel": "^1.0.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.repeat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+			"integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			}
+		},
+		"node_modules/string.prototype.trim": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+			"integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.0",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+			"integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimstart": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/strip-ansi": {
@@ -10919,6 +12210,79 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/typed-array-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-byte-offset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+			"integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-length": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+			"integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13",
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.6.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -10953,6 +12317,21 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/unbox-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/undici-types": {
@@ -11221,6 +12600,85 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
+			"dependencies": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-builtin-type": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
+			"integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
+			"dev": true,
+			"dependencies": {
+				"function.prototype.name": "^1.1.6",
+				"has-tostringtag": "^1.0.2",
+				"is-async-function": "^2.0.0",
+				"is-date-object": "^1.0.5",
+				"is-finalizationregistry": "^1.0.2",
+				"is-generator-function": "^1.0.10",
+				"is-regex": "^1.1.4",
+				"is-weakref": "^1.0.2",
+				"isarray": "^2.0.5",
+				"which-boxed-primitive": "^1.0.2",
+				"which-collection": "^1.0.2",
+				"which-typed-array": "^1.1.15"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-collection": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+			"integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+			"dev": true,
+			"dependencies": {
+				"is-map": "^2.0.3",
+				"is-set": "^2.0.3",
+				"is-weakmap": "^2.0.2",
+				"is-weakset": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+			"integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/why-is-node-running": {
@@ -12135,9 +13593,9 @@
 			"dev": true
 		},
 		"@eslint/plugin-kit": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.1.tgz",
-			"integrity": "sha512-HFZ4Mp26nbWk9d/BpvP0YNL6W4UoZF0VFcTw/aPPA8RpOxeFQgK+ClABGgAUXs9Y/RGX/l1vOmrqz1MQt9MNuw==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+			"integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
 			"dev": true,
 			"requires": {
 				"levn": "^0.4.1"
@@ -14593,6 +16051,97 @@
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
 			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="
 		},
+		"array-buffer-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.5",
+				"is-array-buffer": "^3.0.4"
+			}
+		},
+		"array-includes": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+			"integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"is-string": "^1.0.7"
+			}
+		},
+		"array.prototype.findlast": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+			"integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-shim-unscopables": "^1.0.2"
+			}
+		},
+		"array.prototype.flat": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
+			}
+		},
+		"array.prototype.flatmap": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+			"integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
+			}
+		},
+		"array.prototype.tosorted": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+			"integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-shim-unscopables": "^1.0.2"
+			}
+		},
+		"arraybuffer.prototype.slice": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+			"dev": true,
+			"requires": {
+				"array-buffer-byte-length": "^1.0.1",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.3",
+				"es-errors": "^1.2.1",
+				"get-intrinsic": "^1.2.3",
+				"is-array-buffer": "^3.0.4",
+				"is-shared-array-buffer": "^1.0.2"
+			}
+		},
 		"assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -14603,6 +16152,15 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+		},
+		"available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
+			"requires": {
+				"possible-typed-array-names": "^1.0.0"
+			}
 		},
 		"babel-jest": {
 			"version": "28.1.3",
@@ -14905,6 +16463,19 @@
 			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
 			"dev": true
 		},
+		"call-bind": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"dev": true,
+			"requires": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			}
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -15029,9 +16600,9 @@
 			}
 		},
 		"cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.1.0",
@@ -15065,6 +16636,39 @@
 			"version": "3.0.11",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
 			"integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+		},
+		"data-view-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+			"integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			}
+		},
+		"data-view-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+			"integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			}
+		},
+		"data-view-byte-offset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+			"integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			}
 		},
 		"debug": {
 			"version": "4.3.7",
@@ -15105,6 +16709,28 @@
 			"dev": true,
 			"peer": true
 		},
+		"define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"requires": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			}
+		},
+		"define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"requires": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			}
+		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -15116,6 +16742,15 @@
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
 			"integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ=="
+		},
+		"doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2"
+			}
 		},
 		"dom-accessibility-api": {
 			"version": "0.5.13",
@@ -15164,11 +16799,143 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"es-abstract": {
+			"version": "1.23.5",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
+			"integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
+			"dev": true,
+			"requires": {
+				"array-buffer-byte-length": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.3",
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"data-view-buffer": "^1.0.1",
+				"data-view-byte-length": "^1.0.1",
+				"data-view-byte-offset": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-set-tostringtag": "^2.0.3",
+				"es-to-primitive": "^1.2.1",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.4",
+				"get-symbol-description": "^1.0.2",
+				"globalthis": "^1.0.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.2",
+				"internal-slot": "^1.0.7",
+				"is-array-buffer": "^3.0.4",
+				"is-callable": "^1.2.7",
+				"is-data-view": "^1.0.1",
+				"is-negative-zero": "^2.0.3",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.3",
+				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.13",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.13.3",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.5",
+				"regexp.prototype.flags": "^1.5.3",
+				"safe-array-concat": "^1.1.2",
+				"safe-regex-test": "^1.0.3",
+				"string.prototype.trim": "^1.2.9",
+				"string.prototype.trimend": "^1.0.8",
+				"string.prototype.trimstart": "^1.0.8",
+				"typed-array-buffer": "^1.0.2",
+				"typed-array-byte-length": "^1.0.1",
+				"typed-array-byte-offset": "^1.0.2",
+				"typed-array-length": "^1.0.6",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.15"
+			}
+		},
+		"es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.2.4"
+			}
+		},
+		"es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true
+		},
+		"es-iterator-helpers": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.0.tgz",
+			"integrity": "sha512-tpxqxncxnpw3c93u8n3VOzACmRFoVmWJqbWXvX/JfKbkhBw1oslgPrUfeSt2psuqyEJFD6N/9lg5i7bsKpoq+Q==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-set-tostringtag": "^2.0.3",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"globalthis": "^1.0.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.7",
+				"iterator.prototype": "^1.1.3",
+				"safe-array-concat": "^1.1.2"
+			}
+		},
 		"es-module-lexer": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
 			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
 			"dev": true
+		},
+		"es-object-atoms": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+			"dev": true,
+			"requires": {
+				"es-errors": "^1.3.0"
+			}
+		},
+		"es-set-tostringtag": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.2.4",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.1"
+			}
+		},
+		"es-shim-unscopables": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+			"dev": true,
+			"requires": {
+				"hasown": "^2.0.0"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
 		},
 		"esbuild": {
 			"version": "0.21.5",
@@ -15298,6 +17065,51 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
+				}
+			}
+		},
+		"eslint-plugin-react": {
+			"version": "7.37.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.2.tgz",
+			"integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.1.8",
+				"array.prototype.findlast": "^1.2.5",
+				"array.prototype.flatmap": "^1.3.2",
+				"array.prototype.tosorted": "^1.1.4",
+				"doctrine": "^2.1.0",
+				"es-iterator-helpers": "^1.1.0",
+				"estraverse": "^5.3.0",
+				"hasown": "^2.0.2",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
+				"minimatch": "^3.1.2",
+				"object.entries": "^1.1.8",
+				"object.fromentries": "^2.0.8",
+				"object.values": "^1.2.0",
+				"prop-types": "^15.8.1",
+				"resolve": "^2.0.0-next.5",
+				"semver": "^6.3.1",
+				"string.prototype.matchall": "^4.0.11",
+				"string.prototype.repeat": "^1.0.0"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "2.0.0-next.5",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+					"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.13.0",
+						"path-parse": "^1.0.7",
+						"supports-preserve-symlinks-flag": "^1.0.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+					"dev": true
 				}
 			}
 		},
@@ -15700,6 +17512,15 @@
 			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
 			"dev": true
 		},
+		"for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.3"
+			}
+		},
 		"foreground-child": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -15737,6 +17558,24 @@
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
 		},
+		"function.prototype.name": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
+			}
+		},
+		"functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true
+		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -15749,6 +17588,19 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true,
 			"peer": true
+		},
+		"get-intrinsic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"dev": true,
+			"requires": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			}
 		},
 		"get-package-type": {
 			"version": "0.1.0",
@@ -15763,6 +17615,17 @@
 			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true,
 			"peer": true
+		},
+		"get-symbol-description": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4"
+			}
 		},
 		"glob": {
 			"version": "7.2.0",
@@ -15794,6 +17657,25 @@
 			"integrity": "sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==",
 			"dev": true
 		},
+		"globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			}
+		},
+		"gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.3"
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -15805,6 +17687,42 @@
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
+		},
+		"has-bigints": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+			"dev": true
+		},
+		"has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"requires": {
+				"es-define-property": "^1.0.0"
+			}
+		},
+		"has-proto": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true
+		},
+		"has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.3"
+			}
 		},
 		"hasown": {
 			"version": "2.0.2",
@@ -15888,10 +17806,65 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"internal-slot": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+			"dev": true,
+			"requires": {
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.0",
+				"side-channel": "^1.0.4"
+			}
+		},
+		"is-array-buffer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.1"
+			}
+		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-async-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+			"integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dev": true,
+			"requires": {
+				"has-bigints": "^1.0.1"
+			}
+		},
+		"is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true
 		},
 		"is-core-module": {
 			"version": "2.15.1",
@@ -15901,11 +17874,38 @@
 				"hasown": "^2.0.2"
 			}
 		},
+		"is-data-view": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+			"integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+			"dev": true,
+			"requires": {
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
+		},
+		"is-finalizationregistry": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+			"integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
 		},
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
@@ -15920,6 +17920,15 @@
 			"dev": true,
 			"peer": true
 		},
+		"is-generator-function": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
 		"is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -15929,11 +17938,57 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+			"integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+			"dev": true
+		},
+		"is-negative-zero": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+			"dev": true
+		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
+		},
+		"is-number-object": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-set": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+			"integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+			"dev": true
+		},
+		"is-shared-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7"
+			}
 		},
 		"is-stream": {
 			"version": "2.0.1",
@@ -15941,6 +17996,64 @@
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
 			"dev": true,
 			"peer": true
+		},
+		"is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.2"
+			}
+		},
+		"is-typed-array": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+			"dev": true,
+			"requires": {
+				"which-typed-array": "^1.1.14"
+			}
+		},
+		"is-weakmap": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+			"integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+			"dev": true
+		},
+		"is-weakref": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
+		},
+		"is-weakset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+			"integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4"
+			}
+		},
+		"isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -16034,6 +18147,19 @@
 			"requires": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
+			}
+		},
+		"iterator.prototype": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.3.tgz",
+			"integrity": "sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.2.1",
+				"get-intrinsic": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"reflect.getprototypeof": "^1.0.4",
+				"set-function-name": "^2.0.1"
 			}
 		},
 		"jackspeak": {
@@ -18311,6 +20437,18 @@
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
 		},
+		"jsx-ast-utils": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+			"integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.1.6",
+				"array.prototype.flat": "^1.3.1",
+				"object.assign": "^4.1.4",
+				"object.values": "^1.1.6"
+			}
+		},
 		"keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -18547,6 +20685,64 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-inspect": {
+			"version": "1.13.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+			"integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
+		},
+		"object.assign": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			}
+		},
+		"object.entries": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
+			"integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			}
+		},
+		"object.fromentries": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+			"integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0"
+			}
+		},
+		"object.values": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
+			"integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -18758,6 +20954,12 @@
 				}
 			}
 		},
+		"possible-typed-array-names": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+			"dev": true
+		},
 		"postcss": {
 			"version": "8.4.47",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
@@ -18872,10 +21074,37 @@
 				"strip-indent": "^3.0.0"
 			}
 		},
+		"reflect.getprototypeof": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
+			"integrity": "sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.1",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"globalthis": "^1.0.3",
+				"which-builtin-type": "^1.1.3"
+			}
+		},
 		"regenerator-runtime": {
 			"version": "0.13.9",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
 			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+		},
+		"regexp.prototype.flags": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
+			"integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"set-function-name": "^2.0.2"
+			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -18950,10 +21179,33 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"safe-array-concat": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+			"integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safe-regex-test": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.1.4"
+			}
 		},
 		"scheduler": {
 			"version": "0.23.2",
@@ -18969,6 +21221,32 @@
 			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true
 		},
+		"set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"requires": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			}
+		},
+		"set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dev": true,
+			"requires": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
+			}
+		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -18983,6 +21261,18 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true
+		},
+		"side-channel": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
+			}
 		},
 		"siginfo": {
 			"version": "2.0.0",
@@ -19122,6 +21412,70 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.1"
+			}
+		},
+		"string.prototype.matchall": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
+			"integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.7",
+				"regexp.prototype.flags": "^1.5.2",
+				"set-function-name": "^2.0.2",
+				"side-channel": "^1.0.6"
+			}
+		},
+		"string.prototype.repeat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+			"integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			}
+		},
+		"string.prototype.trim": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+			"integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.0",
+				"es-object-atoms": "^1.0.0"
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+			"integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
 			}
 		},
 		"strip-ansi": {
@@ -19415,6 +21769,58 @@
 			"dev": true,
 			"peer": true
 		},
+		"typed-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"typed-array-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"typed-array-byte-offset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+			"integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+			"dev": true,
+			"requires": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"typed-array-length": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+			"integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13",
+				"possible-typed-array-names": "^1.0.0"
+			}
+		},
 		"typescript": {
 			"version": "5.6.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -19430,6 +21836,18 @@
 				"@typescript-eslint/eslint-plugin": "8.11.0",
 				"@typescript-eslint/parser": "8.11.0",
 				"@typescript-eslint/utils": "8.11.0"
+			}
+		},
+		"unbox-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
+				"which-boxed-primitive": "^1.0.2"
 			}
 		},
 		"undici-types": {
@@ -19569,6 +21987,64 @@
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
+			}
+		},
+		"which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
+			"requires": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			}
+		},
+		"which-builtin-type": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
+			"integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
+			"dev": true,
+			"requires": {
+				"function.prototype.name": "^1.1.6",
+				"has-tostringtag": "^1.0.2",
+				"is-async-function": "^2.0.0",
+				"is-date-object": "^1.0.5",
+				"is-finalizationregistry": "^1.0.2",
+				"is-generator-function": "^1.0.10",
+				"is-regex": "^1.1.4",
+				"is-weakref": "^1.0.2",
+				"isarray": "^2.0.5",
+				"which-boxed-primitive": "^1.0.2",
+				"which-collection": "^1.0.2",
+				"which-typed-array": "^1.1.15"
+			}
+		},
+		"which-collection": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+			"integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+			"dev": true,
+			"requires": {
+				"is-map": "^2.0.3",
+				"is-set": "^2.0.3",
+				"is-weakmap": "^2.0.2",
+				"is-weakset": "^2.0.3"
+			}
+		},
+		"which-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+			"integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+			"dev": true,
+			"requires": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.2"
 			}
 		},
 		"why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"test": "vitest",
 		"coverage": "vitest run --coverage",
 		"build": "tsc -b && vite build",
-		"lint": "eslint .",
+		"lint": "eslint src test",
 		"preview": "vite preview"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@vitejs/plugin-react-swc": "^3.5.0",
 		"@vitest/coverage-v8": "^2.1.5",
 		"eslint": "^9.13.0",
+		"eslint-plugin-react": "^7.37.2",
 		"eslint-plugin-react-hooks": "^5.0.0",
 		"eslint-plugin-react-refresh": "^0.4.13",
 		"globals": "^15.11.0",

--- a/src/components/inventory-editor/DiacriticSelector.tsx
+++ b/src/components/inventory-editor/DiacriticSelector.tsx
@@ -43,9 +43,7 @@ function DiacriticSelector({ diacritic, setDiacritic }: DiacriticSelectorProps) 
 				size="small"
 			>
 				<Tooltip title="Add custom diacritic">
-					<Typography variant="phoneme">
-						{DOTTED_CIRCLE + (diacritic?.label || "")}
-					</Typography>
+					<Typography variant="phoneme">{DOTTED_CIRCLE + (diacritic?.label ?? "")}</Typography>
 				</Tooltip>
 			</Button>
 			<Menu

--- a/src/components/inventory-editor/InventoryEditor.tsx
+++ b/src/components/inventory-editor/InventoryEditor.tsx
@@ -73,7 +73,7 @@ function InventoryEditor({
 		<Dialog open={open} maxWidth="lg">
 			<DialogTitle>Edit Phoneme Inventory</DialogTitle>
 			<Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-				<Tabs value={selectedTab} onChange={(_, v) => setSelectedTab(v)}>
+				<Tabs value={selectedTab} onChange={(_, v: TableTabs) => setSelectedTab(v)}>
 					<Tab label="consonants" value="consonants" />
 					<Tab label="other" value="other" />
 					<Tab label="vowels" value="vowels" />

--- a/src/components/select-features/SelectFeatures.tsx
+++ b/src/components/select-features/SelectFeatures.tsx
@@ -5,17 +5,13 @@ import MenuItem from "@mui/material/MenuItem";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 
-import {
-	FeatureName,
-	featureNames,
-	FeatureValue,
-} from "@/pheatures/FeatureSpecification";
+import { FeatureName, featureNames, FeatureValue } from "@/pheatures/FeatureSpecification";
 
-type FeatureQuery = {
+interface FeatureQuery {
 	value: FeatureValue;
 	name: FeatureName | null;
 	uid: number;
-};
+}
 
 // maintain unique IDs to use as keys in map
 // compared to indexing, this allows reordering, e.g. if earlier row is removed

--- a/src/components/spreadsheet/Spreadsheet.tsx
+++ b/src/components/spreadsheet/Spreadsheet.tsx
@@ -104,7 +104,7 @@ function Spreadsheet({ featureList }: SpreadsheetProps) {
 		setOrderBy(property);
 	};
 
-	const isSelected = (symbol: ComplexSymbol) => selected.indexOf(symbol) !== -1;
+	const isSelected = (symbol: ComplexSymbol) => selected.includes(symbol);
 	const numSelected = selected.length;
 
 	// list of symbols sorted by ordering criterion

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>
 		<App />

--- a/src/pheatures/BaseSymbol.ts
+++ b/src/pheatures/BaseSymbol.ts
@@ -5,9 +5,7 @@ import FeatureSpecification, {
 	FeatureValue,
 } from "./FeatureSpecification";
 
-export interface RawSymbol {
-	[index: string]: string;
-}
+export type RawSymbol = Record<"Unicode" | "Sound" | FeatureName, string>;
 
 // A symbol represents one segment and its features
 class BaseSymbol {

--- a/src/pheatures/BaseSymbolList.ts
+++ b/src/pheatures/BaseSymbolList.ts
@@ -2,6 +2,8 @@ import BaseSymbol, { RawSymbol } from "./BaseSymbol";
 
 // Holds the feature data of the base symbols, those without diacritics
 class BaseSymbolList {
+	// TODO: consider changing to Map
+	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 	symbols: {
 		[index: string]: BaseSymbol;
 	};

--- a/src/pheatures/Diacritics.ts
+++ b/src/pheatures/Diacritics.ts
@@ -14,7 +14,7 @@ class Diacritics {
 	constructor(diacriticsTable: string[][]) {
 		this.items = diacriticsTable.map(([description, label, fromQuery, toQuery]) => {
 			label = label.trim();
-			if (label.match(/\d+/)) {
+			if (/\d+/.test(label)) {
 				// numerical labels are converted to their unicode character
 				label = String.fromCharCode(Number(label));
 			}

--- a/src/pheatures/IPASkeleton.ts
+++ b/src/pheatures/IPASkeleton.ts
@@ -15,6 +15,7 @@ function _subset<T>(a: Iterable<T>, b: Iterable<T>): boolean {
 class IPASkeleton {
 	cells: Cell[][];
 	symbols: ComplexSymbol[];
+	// Tracks the diacritics that characterize each row
 	diacriticSignature: Set<Diacritic>[];
 
 	constructor(rawSkeleton: string[][], symbolList: BaseSymbolList) {
@@ -51,7 +52,9 @@ class IPASkeleton {
 				return symbol;
 			})
 		);
-		this.diacriticSignature = [...Array(this.cells.length)].map(() => new Set());
+		this.diacriticSignature = [...Array<undefined>(this.cells.length)].map(
+			() => new Set()
+		);
 	}
 
 	// Provide equivalent symbols but with references from the skeleton cells
@@ -142,7 +145,7 @@ class IPASkeleton {
 		}
 
 		// insert a new row with the symbol at the correct column
-		const newRow: Cell[] = Array(this.cells[0].length).fill("");
+		const newRow = Array<Cell>(this.cells[0].length).fill("");
 		newRow[baseIndex] = symbol;
 
 		this.cells.splice(rowIndex + 1, 0, newRow);
@@ -188,9 +191,7 @@ class IPASkeleton {
 
 	// Update this.symbols with the symbols in cells
 	_refreshSymbols(): void {
-		this.symbols = this.cells
-			.flat()
-			.filter((cell) => typeof cell !== "string") as ComplexSymbol[];
+		this.symbols = this.cells.flat().filter((cell) => typeof cell !== "string");
 	}
 
 	// Flatten the skeleton cells, keeping only the selected

--- a/src/pheatures/IPASkeleton.ts
+++ b/src/pheatures/IPASkeleton.ts
@@ -71,7 +71,8 @@ class IPASkeleton {
 
 		for (const symbol of symbols) {
 			if (characterMap.has(symbol.displayCharacter)) {
-				references.push(characterMap.get(symbol.displayCharacter) as ComplexSymbol);
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				references.push(characterMap.get(symbol.displayCharacter)!);
 			} else {
 				// Symbol might have additional diacritics or be part of a different table
 				if (this._insertComplexSymbol(symbol)) {

--- a/src/pheatures/Message.tsx
+++ b/src/pheatures/Message.tsx
@@ -1,3 +1,4 @@
+import { ReactElement } from "react";
 import Dependency from "./Dependency";
 import FeatureChange from "./FeatureChange";
 
@@ -10,9 +11,9 @@ enum MessageType {
 class Message {
 	type: MessageType;
 	title: string;
-	detail: JSX.Element;
+	detail: ReactElement;
 
-	constructor(type: MessageType, title: string, detail: JSX.Element) {
+	constructor(type: MessageType, title: string, detail: ReactElement) {
 		this.type = type;
 		this.title = title;
 		this.detail = detail;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,11 @@
 /// <reference types="vite/client" />
-declare module "*.inv";
-declare module "*.tsv";
+
+type Path = string;
+function pathString(): Path;
+
+declare module "*.inv" {
+	export default pathString();
+}
+declare module "*.tsv" {
+	export default pathString();
+}

--- a/test/pheatures/FeatureList.test.ts
+++ b/test/pheatures/FeatureList.test.ts
@@ -20,13 +20,13 @@ const selectionCharacters = (featureList: FeatureList): string[] =>
 const resultCharacters = (featureList: FeatureList): string[] =>
 	featureList.items.map((symbol) => symbol.displayCharacter);
 
-test("can run basic selection and transform", async () => {
+test("can run basic selection and transform", () => {
 	const featureList = new FeatureList(inventoryEnglish, symbolList, "-delayed release", "+voice");
 	expect(selectionCharacters(featureList)).toEqual(["p", "t", "k", "b", "d", "\u0261"]);
 	expect(resultCharacters(featureList)).toEqual(["b", "d", "\u0261", "b", "d", "\u0261"]);
 });
 
-test("warns about unnecessary selection", async () => {
+test("warns about unnecessary selection", () => {
 	const featureList = new FeatureList(
 		inventoryEnglish,
 		symbolList,
@@ -38,7 +38,7 @@ test("warns about unnecessary selection", async () => {
 	expect(featureList.messages[0].title === "Unnecessary features are selected");
 });
 
-test("diacritic in inventory changes features", async () => {
+test("diacritic in inventory changes features", () => {
 	const featureList = new FeatureList(inventoryGerman, symbolList, "+long", "");
 	expect(selectionCharacters(featureList)).toEqual([
 		"u" + DIA.LONG,
@@ -51,14 +51,14 @@ test("diacritic in inventory changes features", async () => {
 	]);
 });
 
-test("finds diacritics for opposing feature", async () => {
+test("finds diacritics for opposing feature", () => {
 	const featureList = new FeatureList(inventoryHypothetical, symbolList, "+front, -voice", "+back");
 	expect(selectionCharacters(featureList)).toEqual(["k" + DIA.FRONTED, "x" + DIA.FRONTED]);
 	expect(resultCharacters(featureList)).toEqual(["k" + DIA.BACKED, "x" + DIA.BACKED]);
 	expect(featureList.messages[0].title === "Additional feature changes were added");
 });
 
-test("finds diacritic for different base character", async () => {
+test("finds diacritic for different base character", () => {
 	const featureList = new FeatureList(
 		inventoryHypothetical,
 		symbolList,
@@ -73,7 +73,7 @@ test("finds diacritic for different base character", async () => {
 	expect(featureList.messages[0].title === "Unnecessary features are selected");
 });
 
-test("reasonable label after multiple changes", async () => {
+test("reasonable label after multiple changes", () => {
 	const featureList = new FeatureList(
 		inventoryHypothetical,
 		symbolList,
@@ -100,7 +100,7 @@ test("reasonable label after multiple changes", async () => {
 	]);
 });
 
-test("changes between diacritics", async () => {
+test("changes between diacritics", () => {
 	const featureList = new FeatureList(inventoryKorean, symbolList, "-delayed release", "+voice");
 	expect(selectionCharacters(featureList)).toEqual([
 		"p",
@@ -126,7 +126,7 @@ test("changes between diacritics", async () => {
 	]);
 });
 
-test("converts to affricates", async () => {
+test("converts to affricates", () => {
 	const featureList = new FeatureList(
 		inventoryHypothetical,
 		symbolList,
@@ -143,7 +143,7 @@ test("converts to affricates", async () => {
 	]);
 });
 
-test("finds affricate with double diacritics", async () => {
+test("finds affricate with double diacritics", () => {
 	const featureList = new FeatureList(
 		inventoryHypothetical,
 		symbolList,
@@ -158,7 +158,7 @@ test("finds affricate with double diacritics", async () => {
 	]);
 });
 
-test("reasonable multiple diacritics", async () => {
+test("reasonable multiple diacritics", () => {
 	const featureList = new FeatureList(inventoryKorean, symbolList, "+dorsal, -sonorant", "+front");
 	expect(selectionCharacters(featureList)).toEqual(["k", "k" + DIA.ASPIRATED, "k" + DIA.EJECTIVE]);
 	expect(resultCharacters(featureList)).toEqual([
@@ -169,7 +169,7 @@ test("reasonable multiple diacritics", async () => {
 	]);
 });
 
-test("changes between diacritics", async () => {
+test("changes between diacritics", () => {
 	const featureList = new FeatureList(
 		inventoryKorean,
 		symbolList,

--- a/test/pheatures/IPASkeleton.test.ts
+++ b/test/pheatures/IPASkeleton.test.ts
@@ -12,7 +12,7 @@ import symbolList from "./SymbolList.test";
 const consonantsChart = parseFile<string[]>(consonantChartsPath, false);
 const skeleton = new IPASkeleton(consonantsChart, symbolList);
 
-test("finds reasonable base candidate: aspirated backed velar plosive", async () => {
+test("finds reasonable base candidate: aspirated backed velar plosive", () => {
 	const symbol = ComplexSymbol.fromBaseSymbol(symbolList.symbols["k"], [
 		diacriticList.getFromName("backed velar"),
 		diacriticList.getFromName("aspirated"),
@@ -21,7 +21,7 @@ test("finds reasonable base candidate: aspirated backed velar plosive", async ()
 	expect(coordinates).toEqual([1, 11]);
 });
 
-test("finds reasonable base candidate: stressed postalveolar plosive", async () => {
+test("finds reasonable base candidate: stressed postalveolar plosive", () => {
 	const symbol = ComplexSymbol.fromBaseSymbol(symbolList.symbols["t"], [
 		diacriticList.getFromName("postalveolar"),
 		diacriticList.getFromName("stressed"),


### PR DESCRIPTION
Resolves #6.

#### Changes
- Use typescript-eslint [`recommended-type-checked`](https://typescript-eslint.io/users/configs/#recommended-type-checked)
  - Update module type for `.inv` and `.tsv` files
  - Resolve lint issues related to TypeScript usage and relax some options
    - Allow `FeatureChange` in [`restrict-template-expressions`](https://typescript-eslint.io/rules/restrict-template-expressions/)
    - Ignore static methods in [`unbound-method`](https://typescript-eslint.io/rules/unbound-method/)
  - Change `async` tests to regular arrow functions
- Further restrict with typescript-eslint [`strict-type-checked`](https://typescript-eslint.io/users/configs/#strict-type-checked)
  - Replace `JSX.Element` type with `ReactElement`
  - Ignore arrow shorthand for [`no-confusing-void-expression`](https://typescript-eslint.io/rules/no-confusing-void-expression/)
  - Allow non-null assertion for `createRoot` in `main.tsx`
- Use typescript-eslint [`stylistic-type-checked`](https://typescript-eslint.io/users/configs/#stylistic-type-checked)
  - Change from `type` to `interface` and index signature to `Record`
    - Specify explicit keys for `RawSymbol` type
  - Make other required stylistic adjustments
  - Allow array notation for property from index signature
    - Might consider changing `BaseSymbolList.symbols` to be a `Map`
- Add [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react) configuration and rules
  - Just default recommended rules for now